### PR TITLE
ingestr: Fix importing from Kafka per `SystemColumnWorkaround`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,4 +7,4 @@
 - Satisfied `mypy` type checker
 
 ## 2025/06/24 v0.0.0
-- Start of project, derived from https://github.com/dlt-hub/dlt/pull/2733
+- Started the project, derived from https://github.com/dlt-hub/dlt/pull/2733

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- ingestr: Fixed importing from Kafka per `SystemColumnWorkaround`
 
 ## 2025/06/24 v0.0.1
 - Fixed mypy error `missing library stubs or py.typed marker`

--- a/src/dlt_cratedb/impl/cratedb/utils.py
+++ b/src/dlt_cratedb/impl/cratedb/utils.py
@@ -68,11 +68,16 @@ class SystemColumnWorkaround:
     """
 
     quirked_labels = [
+        # dlt core
         "__dlt_id",
         "__dlt_load_id",
         "__dlt_parent_id",
         "__dlt_list_idx",
         "__dlt_root_id",
+        # ingestr kafka
+        "_kafka__msg_id",
+        # ingestr mongodb
+        # "__id",
     ]
 
     @staticmethod
@@ -83,6 +88,7 @@ class SystemColumnWorkaround:
             .replace("_dlt_parent_id", "__dlt_parent_id")
             .replace("_dlt_list_idx", "__dlt_list_idx")
             .replace("_dlt_root_id", "__dlt_root_id")
+            .replace("_kafka_msg_id", "_kafka__msg_id")
         )
         return thing
 
@@ -94,6 +100,7 @@ class SystemColumnWorkaround:
             .replace("__dlt_parent_id", "_dlt_parent_id")
             .replace("__dlt_list_idx", "_dlt_list_idx")
             .replace("__dlt_root_id", "_dlt_root_id")
+            .replace("_kafka__msg_id", "_kafka_msg_id")
         )
         return thing
 


### PR DESCRIPTION
## About
When evaluating the CrateDB destination adapter with the Kafka source in ingestr, the process is failing on the venerable `InvalidColumnNameException`.

## References
- https://github.com/crate-workbench/ingestr/issues/3