### PR TITLE
Fix importing from MongoDB: escape CrateDB reserved system column names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fixed importing from MongoDB: columns that collide with CrateDB's reserved
+  system column names (most notably MongoDB's `_id`) are now renamed with a
+  leading underscore (e.g. `_id` -> `__id`) via a dedicated naming convention,
+  instead of failing with `"_id" conflicts with system column`.
+
 ## 2026/03/10 v0.1.1
 
 - Fixed CrateDB crashes by configuring `caps.max_query_length` to 4MB

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Please refer to the [overview] and the [usage guide].
 - The `cratedb` adapter is heavily based on the `postgres` adapter.
 - The `CrateDbSqlClient` deviates from the original `Psycopg2SqlClient` by
   adding a few CrateDB-specific adjustments.
+- A CrateDB-specific naming convention renames columns that collide with
+  CrateDB's reserved system column names, such as MongoDB's `_id`.
 
 ## Backlog
 

--- a/src/dlt_cratedb/impl/cratedb/factory.py
+++ b/src/dlt_cratedb/impl/cratedb/factory.py
@@ -77,6 +77,12 @@ class cratedb(postgres, Destination[CrateDbClientConfiguration, "CrateDbClient"]
         # TODO: Escaping might need further adjustments, to be explored using integration tests.
         caps.escape_literal = escape_cratedb_literal
 
+        # CrateDB reserves a fixed set of `_`-prefixed system column names (e.g. `_id`,
+        # which MongoDB stamps on every document). Use a naming convention that renames
+        # those to a double-underscore variant to avoid `conflicts with system column`.
+        # https://github.com/crate/dlt-cratedb/issues/19
+        caps.naming_convention = "dlt_cratedb.impl.cratedb.naming"
+
         # CrateDB does not support direct data loading using advanced formats.
         # TODO: Explore adding more formats for staged imports.
         caps.preferred_loader_file_format = "insert_values"

--- a/src/dlt_cratedb/impl/cratedb/naming.py
+++ b/src/dlt_cratedb/impl/cratedb/naming.py
@@ -1,0 +1,41 @@
+from dlt.common.normalizers.naming.snake_case import NamingConvention as SnakeCaseNamingConvention
+
+from dlt_cratedb.impl.cratedb.utils import RESERVED_SYSTEM_COLUMNS
+
+# The escaped form of each reserved name, e.g. `_id` -> `__id`. Used to keep the
+# rename idempotent under `normalize_path` (see `normalize_path` below).
+ESCAPED_SYSTEM_COLUMNS = frozenset("_" + name for name in RESERVED_SYSTEM_COLUMNS)
+
+
+class NamingConvention(SnakeCaseNamingConvention):
+    """
+    Snake-case naming, with a CrateDB twist: rename columns that collide with
+    CrateDB's reserved system column names by prepending an underscore.
+
+    MongoDB stamps every document with a top-level `_id`, and CrateDB reserves
+    `_id` (and a handful of others in RESERVED_SYSTEM_COLUMNS), so a plain load fails with::
+
+        InvalidColumnNameException["_id" conflicts with system column]
+
+    Renaming `_id` -> `__id` sidesteps the conflict (this matches the convention
+    CrateDB Toolkit's native MongoDB adapter already uses). dlt records the
+    *normalized* name in its own schema, so the rewrite is consistent end-to-end
+    (DDL + INSERT) and needs no reverse mapping on read.
+
+    @see: https://github.com/crate/dlt-cratedb/issues/19
+    """
+
+    def normalize_identifier(self, identifier: str) -> str:
+        norm = super().normalize_identifier(identifier)
+        if norm in RESERVED_SYSTEM_COLUMNS:
+            norm = "_" + norm
+        return norm
+
+    def normalize_path(self, path: str) -> str:
+        # Short-circuit escaped top-level names to keep the rewrite idempotent.
+        # `__` is dlt's nested-path separator, so `__id` fed through `break_path`
+        # would split to `id`. dlt re-normalizes compound hints (e.g. `primary_key`)
+        # this way. Only top-level columns matter; CrateDB enforces reservation there.
+        if path in ESCAPED_SYSTEM_COLUMNS:
+            return path
+        return super().normalize_path(path)

--- a/src/dlt_cratedb/impl/cratedb/utils.py
+++ b/src/dlt_cratedb/impl/cratedb/utils.py
@@ -8,6 +8,28 @@ from dlt.common.data_writers.escape import _escape_extended, _make_sql_escape_re
 SQL_ESCAPE_DICT = {"'": "''"}
 SQL_ESCAPE_RE = _make_sql_escape_re(SQL_ESCAPE_DICT)
 
+# CrateDB reserves a fixed set of system column names. Defining a top-level column with
+# one of these names fails with `InvalidColumnNameException[... conflicts with system column]`.
+# This is an *exact* match, not a pattern: since CrateDB 6.2 (crate/crate#15161) the generic
+# `_`-prefix restriction was lifted, so only these specific names remain reserved. Object
+# sub-keys are unaffected. Source of truth: crate/crate `SysColumns.NAMES`.
+# https://github.com/crate/crate/issues/15161
+RESERVED_SYSTEM_COLUMNS = frozenset(
+    {
+        "_id",
+        "_version",
+        "_score",
+        "_uid",
+        "_doc",
+        "_raw",
+        "_seq_no",
+        "_primary_term",
+        "_tombstone",
+        "_fetchid",
+        "_docid",
+    }
+)
+
 
 def _escape_extended_cratedb(v: str) -> str:
     """

--- a/tests/load/cratedb/test_cratedb_table_builder.py
+++ b/tests/load/cratedb/test_cratedb_table_builder.py
@@ -183,6 +183,38 @@ def test_create_table_case_sensitive(cs_client: CrateDbClient) -> None:
         assert line.startswith('"Col')
 
 
+@pytest.fixture
+def reserved_client(empty_schema: Schema, credentials: CrateDbCredentials) -> CrateDbClient:
+    # Switch to the CrateDB naming convention, which escapes reserved system column names.
+    empty_schema._normalizers_config["names"] = "dlt_cratedb.impl.cratedb.naming"
+    empty_schema.update_normalizers()
+    return create_client(empty_schema, credentials=credentials)
+
+
+def test_create_table_escapes_reserved_columns(reserved_client: CrateDbClient) -> None:
+    # MongoDB stamps every document with `_id`, which collides with one of CrateDB's
+    # reserved system columns. The CrateDB naming convention renames it to `__id` so
+    # the `CREATE TABLE` no longer raises `"_id" conflicts with system column`.
+    # https://github.com/crate/dlt-cratedb/issues/19
+    table_name = "people"
+    reserved_client.schema.update_table(
+        utils.new_table(
+            table_name,
+            columns=[
+                {"name": "_id", "data_type": "text", "nullable": False},
+                {"name": "name", "data_type": "text", "nullable": True},
+                {"name": "_dlt_id", "data_type": "text", "nullable": False},
+            ],
+        )
+    )
+    columns = list(reserved_client.schema.get_table_columns(table_name).values())
+    sql = reserved_client._get_table_update_sql(table_name, columns, False)[0]
+    assert '"__id"' in sql  # `_id` is renamed ...
+    assert '"_id"' not in sql  # ... so the bare reserved name never reaches the DDL
+    assert '"name"' in sql  # non-reserved column, untouched
+    assert '"_dlt_id"' in sql  # dlt's own column is not reserved, untouched
+
+
 def test_create_dlt_table(client: CrateDbClient) -> None:
     # non existing table
     sql = client._get_table_update_sql("_dlt_version", TABLE_UPDATE, False)[0]

--- a/tests/load/cratedb/test_naming.py
+++ b/tests/load/cratedb/test_naming.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for the CrateDB naming convention that works around CrateDB's reserved
+system column names (e.g. MongoDB's `_id`).
+
+See: https://github.com/crate/dlt-cratedb/issues/19
+"""
+
+import pytest
+
+from dlt_cratedb.impl.cratedb.naming import NamingConvention
+from dlt_cratedb.impl.cratedb.utils import RESERVED_SYSTEM_COLUMNS
+
+
+@pytest.fixture
+def naming() -> NamingConvention:
+    return NamingConvention()
+
+
+def test_reserved_names_are_escaped(naming: NamingConvention) -> None:
+    for name in RESERVED_SYSTEM_COLUMNS:
+        assert naming.normalize_identifier(name) == "_" + name
+
+
+def test_mongodb_id_is_escaped(naming: NamingConvention) -> None:
+    assert naming.normalize_identifier("_id") == "__id"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "_foo",  # single leading underscore but not reserved -> allowed since CrateDB 6.2
+        "_dlt_id",  # dlt's own bookkeeping columns are not reserved
+        "_dlt_load_id",
+        "id",
+        "name",
+        "user_name",
+    ],
+)
+def test_non_reserved_names_pass_through(naming: NamingConvention, name: str) -> None:
+    assert naming.normalize_identifier(name) == name
+
+
+def test_normalize_identifier_is_idempotent(naming: NamingConvention) -> None:
+    once = naming.normalize_identifier("_id")
+    assert naming.normalize_identifier(once) == once == "__id"
+
+
+def test_normalize_path_is_idempotent(naming: NamingConvention) -> None:
+    # `__` is dlt's nested-path separator; the escaped name must survive being fed
+    # back through `normalize_path` (which dlt does for compound hints like
+    # `primary_key`), otherwise `__id` would be split apart into `id`.
+    once = naming.normalize_path("_id")
+    assert once == "__id"
+    assert naming.normalize_path(once) == "__id"
+    assert naming.normalize_path(naming.normalize_path(once)) == "__id"


### PR DESCRIPTION
Fixes importing data whose columns collide with CrateDB's reserved system column names — most notably MongoDB's `_id`, which every document carries. Such loads currently fail at `CREATE TABLE` with:

```
dlt.destinations.exceptions.DatabaseTransientException: "_id" conflicts with system column
```

Unblocks CTK's ingestr→dlt MongoDB route (crate/cratedb-toolkit#498, crate/crate-clients-tools#86).

Fixes #19.
