### PR TITLE
Fix CrateDB `merge`, `delete-insert`, and `refresh="drop_resources"` crashes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:latest
+        image: crate/crate:nightly
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,15 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
+    services:
+      cratedb:
+        image: crate/crate:nightly
+        ports:
+          - 4200:4200
+          - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 2g
+
     steps:
 
       - name: Acquire sources

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:latest
         ports:
           - 4200:4200
           - 5432:5432
@@ -72,6 +72,15 @@ jobs:
           timezoneLinux: "Europe/Berlin"
           timezoneMacos: "Europe/Berlin"
           timezoneWindows: "European Standard Time"
+
+      - name: Wait for CrateDB
+        run: |
+          for _ in $(seq 1 60); do
+            if curl -sf http://localhost:4200/ >/dev/null; then echo "CrateDB ready"; exit 0; fi
+            sleep 2
+          done
+          echo "CrateDB not ready in time" >&2
+          exit 1
 
       - name: Run linters and software tests
         run: poe check

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fixed `merge`, `delete-insert`, and `refresh="drop_resources"` crashing on CrateDB
+  (GH-14): the datetime type mapper no longer mutates the live schema (which tripped
+  `DestinationSchemaTampered`), and deleting a schema now tolerates an already-dropped
+  `_dlt_version` table instead of aborting the load.
 - Fixed importing from MongoDB: columns that collide with CrateDB's reserved
   system column names (most notably MongoDB's `_id`) are now renamed with a
   leading underscore (e.g. `_id` -> `__id`) via a dedicated naming convention,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ packages = [
 ]
 exclude = [
 ]
-python_version = "3.10"
+python_version = "3.12"
 ignore_missing_imports = false
 strict_optional = false
 warn_redundant_casts = true

--- a/src/dlt_cratedb/impl/cratedb/cratedb.py
+++ b/src/dlt_cratedb/impl/cratedb/cratedb.py
@@ -9,6 +9,7 @@ from dlt.common.destination.client import (
     PreparedTableSchema,
 )
 from dlt.common.schema import Schema, TColumnHint
+from dlt.destinations.exceptions import DatabaseUndefinedRelation
 from dlt.destinations.impl.postgres.postgres import PostgresClient
 from dlt.destinations.insert_job_client import InsertValuesJobClient
 from dlt.destinations.sql_client import SqlClientBase
@@ -132,9 +133,18 @@ class CrateDbClient(PostgresClient):
 
     def _delete_schema_in_storage(self, schema: Schema) -> None:
         """
-        Intercept to invoke a `REFRESH TABLE ...` statement.
+        Intercept to invoke a `REFRESH TABLE ...` statement, and tolerate a missing
+        version table. (#14)
         """
-        result = super()._delete_schema_in_storage(schema=schema)
+        try:
+            result = super()._delete_schema_in_storage(schema=schema)
+        except DatabaseUndefinedRelation:
+            logger.debug(
+                "Version table %s absent while deleting schema %s; nothing to delete.",
+                self.schema.version_table_name,
+                schema.name,
+            )
+            return None
         table_name = self.sql_client.make_qualified_table_name(self.schema.version_table_name)
         self.sql_client.execute_sql(f"REFRESH TABLE {table_name}")
         return result

--- a/src/dlt_cratedb/impl/cratedb/factory.py
+++ b/src/dlt_cratedb/impl/cratedb/factory.py
@@ -44,27 +44,15 @@ class CrateDbTypeMapper(PostgresTypeMapper):
         table: PreparedTableSchema = None,
     ) -> str:
         """
-        Render against a *copy* of the column.
-
-        `to_db_datetime_type` nullifies `precision` in place, but `column` is a live
-        reference into the dlt `Schema`. Mutating it there changes the schema hash mid-load,
-        which trips `DestinationSchemaTampered` on the staging pass of `merge`/`delete-insert`.
-
+        - CrateDB has no `timestamp(precision)` type, so drop `precision` before rendering.
+        - Render against a copy: `column` is a live reference into the dlt `Schema`, and
+        mutating it changes the schema hash mid-load, tripping `DestinationSchemaTampered`
+        on the staging pass of `merge` / `delete-insert`.
         https://github.com/crate/dlt-cratedb/issues/14
         """
-        return super().to_destination_type(dict(column), table)  # type: ignore[arg-type]
-
-    def to_db_datetime_type(
-        self,
-        column: TColumnSchema,
-        table: PreparedTableSchema = None,
-    ) -> str:
-        """
-        CrateDB does not support `timestamp(6) without time zone`.
-        To not render the SQL clause like this, nullify the `precision` attribute.
-        """
-        column["precision"] = None
-        return super().to_db_datetime_type(column, table)
+        if column.get("data_type") == "timestamp":
+            column = {**column, "precision": None}
+        return super().to_destination_type(column, table)  # type: ignore[arg-type]
 
 
 class cratedb(postgres, Destination[CrateDbClientConfiguration, "CrateDbClient"]):

--- a/src/dlt_cratedb/impl/cratedb/factory.py
+++ b/src/dlt_cratedb/impl/cratedb/factory.py
@@ -38,6 +38,22 @@ class CrateDbTypeMapper(PostgresTypeMapper):
 
         return super().__new__(cls)
 
+    def to_destination_type(
+        self,
+        column: TColumnSchema,
+        table: PreparedTableSchema = None,
+    ) -> str:
+        """
+        Render against a *copy* of the column.
+
+        `to_db_datetime_type` nullifies `precision` in place, but `column` is a live
+        reference into the dlt `Schema`. Mutating it there changes the schema hash mid-load,
+        which trips `DestinationSchemaTampered` on the staging pass of `merge`/`delete-insert`.
+
+        https://github.com/crate/dlt-cratedb/issues/14
+        """
+        return super().to_destination_type(dict(column), table)  # type: ignore[arg-type]
+
     def to_db_datetime_type(
         self,
         column: TColumnSchema,

--- a/tests/load/cratedb/conftest.py
+++ b/tests/load/cratedb/conftest.py
@@ -1,4 +1,8 @@
+from typing import Iterator
+
 import pytest
+from dlt.common.configuration.container import Container
+from dlt.common.destination import DestinationCapabilitiesContext
 
 from dlt_cratedb.impl.cratedb.configuration import CrateDbCredentials
 
@@ -10,3 +14,21 @@ def credentials() -> CrateDbCredentials:
     creds.password = ""
     creds.host = "localhost"
     return creds
+
+
+@pytest.fixture(autouse=True)
+def reset_capabilities_container() -> Iterator[None]:
+    """Clear destination capabilities left injected in the global Container.
+
+    Running a real pipeline injects CrateDB's `DestinationCapabilitiesContext` into the process-wide Container
+    and never removes it. That leaks into later client builds: an explicit case-sensitive schema gets
+    overridden by CrateDB's case-insensitive naming, making tests order-dependent (e.g.
+    `test_create_table_case_sensitive` fails only after an integration test ran).
+    We have to clear it around each test.
+    """
+    container = Container()
+    if DestinationCapabilitiesContext in container:
+        del container[DestinationCapabilitiesContext]
+    yield
+    if DestinationCapabilitiesContext in container:
+        del container[DestinationCapabilitiesContext]

--- a/tests/load/cratedb/test_cratedb_merge.py
+++ b/tests/load/cratedb/test_cratedb_merge.py
@@ -40,6 +40,14 @@ def _row_count(pipeline: dlt.Pipeline, table_name: str) -> int:
             return int(cur.fetchone()[0])
 
 
+def _names(pipeline: dlt.Pipeline, table_name: str) -> set:
+    with pipeline.sql_client() as client:
+        qualified = client.make_qualified_table_name(table_name)
+        client.execute_sql(f"REFRESH TABLE {qualified}")
+        with client.execute_query(f"SELECT name FROM {qualified}") as cur:
+            return {row[0] for row in cur.fetchall()}
+
+
 def test_merge_does_not_tamper_schema(credentials: CrateDbCredentials) -> None:
     """Two consecutive `merge` loads must not raise `DestinationSchemaTampered`."""
     dataset_name = _dataset_name()
@@ -61,9 +69,9 @@ def test_merge_does_not_tamper_schema(credentials: CrateDbCredentials) -> None:
     info2 = pipeline.run(second, table_name="people", write_disposition="merge", primary_key="id")
     assert not info2.has_failed_jobs
 
-    # `merge` is redirected to a full replace on CrateDB (GH-6), so only the 2nd load
-    # survives. We check it doesn't crash and data lands, not merge semantics.
-    assert _row_count(pipeline, "people") == len(second)
+    # `merge` is redirected to a full replace on CrateDB (GH-6): the 2nd load replaces the
+    # 1st, so only `second`'s rows remain.
+    assert _names(pipeline, "people") == {"Bob v2", "Carol"}
 
 
 def test_delete_insert_without_primary_key(credentials: CrateDbCredentials) -> None:

--- a/tests/load/cratedb/test_cratedb_merge.py
+++ b/tests/load/cratedb/test_cratedb_merge.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for crate/dlt-cratedb#14.
+
+`merge` / `delete-insert` write dispositions and `refresh="drop_resources"` used to crash
+on the CrateDB adapter with either:
+
+- `DestinationSchemaTampered` (schema version-hash mismatch during the load step), or
+- `DatabaseUndefinedRelation: Relation 'testdrive_staging._dlt_version' unknown`.
+"""
+
+import uuid
+from typing import Any, Dict, List
+
+import dlt
+
+import dlt_cratedb  # noqa: F401  -- registers `dlt.destinations.cratedb`
+from dlt_cratedb.impl.cratedb.configuration import CrateDbCredentials
+
+
+def _dataset_name() -> str:
+    # Stable within a test (dev_mode off) so its repeated loads share one dataset,
+    # unique across tests for isolation.
+    return "test_merge_" + uuid.uuid4().hex[:12]
+
+
+def _pipeline(credentials: CrateDbCredentials, dataset_name: str) -> dlt.Pipeline:
+    return dlt.pipeline(
+        pipeline_name="test_cratedb_merge_" + dataset_name,
+        destination=dlt.destinations.cratedb(credentials=credentials),
+        dataset_name=dataset_name,
+        dev_mode=False,
+    )
+
+
+def _row_count(pipeline: dlt.Pipeline, table_name: str) -> int:
+    with pipeline.sql_client() as client:
+        qualified = client.make_qualified_table_name(table_name)
+        client.execute_sql(f"REFRESH TABLE {qualified}")
+        with client.execute_query(f"SELECT COUNT(*) FROM {qualified}") as cur:
+            return int(cur.fetchone()[0])
+
+
+def test_merge_does_not_tamper_schema(credentials: CrateDbCredentials) -> None:
+    """Two consecutive `merge` loads must not raise `DestinationSchemaTampered`."""
+    dataset_name = _dataset_name()
+    pipeline = _pipeline(credentials, dataset_name)
+
+    first: List[Dict[str, Any]] = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+    ]
+    second: List[Dict[str, Any]] = [
+        {"id": 2, "name": "Bob v2"},  # update
+        {"id": 3, "name": "Carol"},  # insert
+    ]
+
+    info1 = pipeline.run(first, table_name="people", write_disposition="merge", primary_key="id")
+    assert not info1.has_failed_jobs
+
+    # The 2nd load triggers the staging pass that used to crash.
+    info2 = pipeline.run(second, table_name="people", write_disposition="merge", primary_key="id")
+    assert not info2.has_failed_jobs
+
+    # `merge` is redirected to a full replace on CrateDB (GH-6), so only the 2nd load
+    # survives. We check it doesn't crash and data lands, not merge semantics.
+    assert _row_count(pipeline, "people") == len(second)
+
+
+def test_delete_insert_without_primary_key(credentials: CrateDbCredentials) -> None:
+    dataset_name = _dataset_name()
+    pipeline = _pipeline(credentials, dataset_name)
+
+    rows: List[Dict[str, Any]] = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+    info1 = pipeline.run(
+        rows,
+        table_name="people",
+        write_disposition={"disposition": "merge", "strategy": "delete-insert"},
+    )
+    assert not info1.has_failed_jobs
+
+    info2 = pipeline.run(
+        rows,
+        table_name="people",
+        write_disposition={"disposition": "merge", "strategy": "delete-insert"},
+    )
+    assert not info2.has_failed_jobs
+
+
+def test_refresh_drop_resources(credentials: CrateDbCredentials) -> None:
+    dataset_name = _dataset_name()
+    pipeline = _pipeline(credentials, dataset_name)
+
+    @dlt.resource(name="people", write_disposition="append")
+    def people():
+        yield {"id": 1, "name": "Alice"}
+        yield {"id": 2, "name": "Bob"}
+
+    info1 = pipeline.run(people(), refresh="drop_resources")
+    assert not info1.has_failed_jobs
+
+    # 2nd invocation drops resources first, then re-creates — the documented failure point.
+    info2 = pipeline.run(people(), refresh="drop_resources")
+    assert not info2.has_failed_jobs
+
+    # 3rd invocation, where the issue reports the secondary staging `_dlt_version` error.
+    info3 = pipeline.run(people(), refresh="drop_resources")
+    assert not info3.has_failed_jobs
+
+    assert _row_count(pipeline, "people") == 2
+
+
+def test_refresh_with_missing_staging_version_table(credentials: CrateDbCredentials) -> None:
+    """`refresh="drop_resources"` must not crash when the staging `_dlt_version` is gone.
+
+    Secondary symptom of GH-14: a staging dataset can look initialized (our `_placeholder`
+    table) while `_dlt_version` is gone — the partial state ingestr's ephemeral jobs leave.
+    dlt then deletes from a missing `_dlt_version` and used to abort the load.
+    """
+    dataset_name = _dataset_name()
+    pipeline = _pipeline(credentials, dataset_name)
+
+    @dlt.resource(name="people", write_disposition="append")
+    def people():
+        yield {"id": 1, "name": "Alice"}
+
+    pipeline.run(people(), refresh="drop_resources")
+    pipeline.run(people(), refresh="drop_resources")  # creates the staging dataset
+
+    # Simulate the partial staging state: keep the placeholder, drop `_dlt_version`.
+    staging_dataset = dataset_name + "_staging"
+    with pipeline.sql_client() as client:
+        client.execute_sql(f'CREATE TABLE IF NOT EXISTS "{staging_dataset}"._placeholder (id INT)')
+        client.execute_sql(f'DROP TABLE IF EXISTS "{staging_dataset}"."_dlt_version"')
+
+    info = pipeline.run(people(), refresh="drop_resources")
+    assert not info.has_failed_jobs


### PR DESCRIPTION
`merge` and `delete-insert` write dispositions, and `refresh="drop_resources"`, crashed on the CrateDB destination. This is the second half of getting a full MongoDB-via-ingestr sync working. 

While #19  made `_id` loadable, this makes incremental/refresh loads not abort.

Two independent bugs were hiding behind #14 :

### 1. `DestinationSchemaTampered`

`CrateDbTypeMapper.to_db_datetime_type` dropped a timestamp column's `precision` by mutating the column **in place** — but that column is a live reference into dlt's `Schema`. Rendering the DDL for the `_dlt_*` bookkeeping tables silently changed the schema's content hash mid-load. Plain loads fingerprint the schema once (before rendering) so they never noticed; `merge`/`delete-insert` fingerprint a second time on the staging-dataset pass and tripped the "schema was tampered with" guard.

Fix: rendered against a copy of the column, leaving dlt's schema untouched.

### 2. `Relation '<dataset>_staging._dlt_version' unknown`

dlt deletes old `_dlt_version` rows during cleanup and documents it as a silent no-op when that table is absent — but it only skips the delete when the dataset reports as uninitialised. On CrateDB schemas are implicit, so our `_placeholder` table makes a staging dataset look initialised even after `_dlt_version` has been swept away (the partial state ingestr's ephemeral jobs leave behind). The delete then hit a missing relation and aborted the load.

Fix: `CrateDbClient._delete_schema_in_storage` swallows `DatabaseUndefinedRelation`, honouring
dlt's documented "nothing to delete" contract.

---

`merge` stays redirected to a full replace (`CrateDbStagingReplaceJob`); real upsert semantics remain tracked by #6 . This PR only stops the crashes.

Regression tests for the affected scenarios.

Fixes #14 