### PR TITLE
Chore: Fix packaging for dynamic installs from Git repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,9 @@ describe-subst = "$Format:%(describe:tags,match=v*)$"
 # Emit PyPI-compatible "dirty" version strings. `+` characters are unsuitable, because
 # they would designate local version identifiers, which do not upload to PyPI.
 # https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers
-distance = "{base_version}.post{build_date:%Y%m%d%H%M%S}"
+# distance = "{base_version}.post{build_date:%Y%m%d%H%M%S}"
+# Package metadata version `0.1.1.post20260709230853` does not match `0.1.1.post20260709230854` from the wheel filename
+distance = "{base_version}.post{build_date:%Y%m%d%H%M}"
 
 # ===================
 # Tasks configuration


### PR DESCRIPTION
Hi. This subtle change is needed to be able to install the package from its GitHub repository using a specification as outlined below. 🙏 

```
dlt-cratedb @ git+https://github.com/zerotired/dlt-cratedb.git@main
```

Otherwise, the installation process will fail like this, where you can spot the anomaly on the "seconds" part of the version number. Because of that deviation, the installer rejects the installation. 💥 
```
Package metadata version `0.1.1.post20260709230853` does not match `0.1.1.post20260709230854` from the wheel filename
```

/cc @florinutz 