### PR TITLE
CI: Stop publishing to TestPyPI on PRs from project forks

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -64,6 +64,7 @@ jobs:
           uvx twine check dist/*
 
       - name: Publish package to TestPyPI
+        if: ${{ ! github.event.pull_request.head.repo.fork }}
         run: |
           uv publish --publish-url https://test.pypi.org/legacy/
 


### PR DESCRIPTION
## Problem

When submitting PRs from forks, the `release-pypi.yml` workflow fails, because external projects obviously don't have relevant permissions.

## Solution

Skip the workflow step that publishes to PyPI when PRs are originating from project forks.

/cc @florinutz 